### PR TITLE
Default to dark theme, ignore system preference

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -56,15 +56,8 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
       const saved = localStorage.getItem('theme');
       if (saved === 'light') {
         document.documentElement.classList.add('light');
-      } else if (saved === 'dark') {
-        document.documentElement.classList.add('dark');
       } else {
-        // system preference
-        if (window.matchMedia('(prefers-color-scheme: light)').matches) {
-          document.documentElement.classList.add('light');
-        } else {
-          document.documentElement.classList.add('dark');
-        }
+        document.documentElement.classList.add('dark');
       }
     })();
   </script>
@@ -143,15 +136,6 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
         localStorage.setItem('theme', isLight ? 'dark' : 'light');
       });
     }
-
-    // Follow system theme changes when user hasn't set a preference
-    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-      if (!localStorage.getItem('theme')) {
-        const html = document.documentElement;
-        html.classList.remove('light', 'dark');
-        html.classList.add(e.matches ? 'dark' : 'light');
-      }
-    });
 
     // Intersection observer for scroll animations
     const observer = new IntersectionObserver((entries) => {


### PR DESCRIPTION
## Summary
- Always initialize with the dark theme on first load instead of reading `prefers-color-scheme`
- Manual toggle and persisted user choice in localStorage continue to work
- Removed the system-theme change listener since system preference is no longer consulted

## Test plan
- [ ] Load the site with no `theme` in localStorage → renders dark
- [ ] Toggle to light → persists across reloads
- [ ] Toggle back to dark → persists across reloads