### PR TITLE
Improve blog post typography and image presentation

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -750,6 +750,17 @@ footer {
   border-radius: var(--radius);
 }
 
+.prose-blog img {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  max-height: 70vh;
+  width: auto;
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--radius);
+}
+
 .prose-blog code:not(pre code) {
   background: var(--tech-bg);
   padding: 2px 6px;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -728,21 +728,66 @@ footer {
 
 /* ── Prose (blog post content) ── */
 .prose-blog {
-  @apply prose prose-lg max-w-none;
-  --tw-prose-body: var(--text-secondary);
-  --tw-prose-headings: var(--text);
-  --tw-prose-links: var(--accent);
-  --tw-prose-bold: var(--text);
-  --tw-prose-code: var(--text);
-  --tw-prose-pre-bg: var(--bg-raised);
-  --tw-prose-pre-code: var(--text-secondary);
-  --tw-prose-quotes: var(--text-secondary);
-  --tw-prose-quote-borders: var(--accent);
-  --tw-prose-counters: var(--text-muted);
-  --tw-prose-bullets: var(--text-muted);
-  --tw-prose-hr: var(--border);
-  --tw-prose-th-borders: var(--border);
-  --tw-prose-td-borders: var(--border);
+  color: var(--text-secondary);
+  font-size: 1.0625rem;
+  line-height: 1.75;
+}
+
+.prose-blog > * + * {
+  margin-top: 1.5em;
+}
+
+.prose-blog p {
+  margin: 0 0 1.5em;
+}
+
+.prose-blog p:last-child {
+  margin-bottom: 0;
+}
+
+.prose-blog h1,
+.prose-blog h2,
+.prose-blog h3,
+.prose-blog h4 {
+  color: var(--text);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.25;
+  margin-top: 2.25em;
+  margin-bottom: 0.75em;
+}
+
+.prose-blog h2 { font-size: 1.625rem; }
+.prose-blog h3 { font-size: 1.3125rem; }
+.prose-blog h4 { font-size: 1.125rem; }
+
+.prose-blog ul,
+.prose-blog ol {
+  margin: 0 0 1.5em;
+  padding-left: 1.5em;
+}
+
+.prose-blog li {
+  margin: 0.375em 0;
+}
+
+.prose-blog blockquote {
+  margin: 1.5em 0;
+  padding: 0.25em 1em;
+  border-left: 3px solid var(--accent);
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+.prose-blog hr {
+  border: 0;
+  border-top: 1px solid var(--border);
+  margin: 2.5em 0;
+}
+
+.prose-blog strong {
+  color: var(--text);
+  font-weight: 700;
 }
 
 .prose-blog pre {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -761,6 +761,20 @@ footer {
   border-radius: var(--radius);
 }
 
+.prose-blog p:has(> img) {
+  text-align: center;
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  font-style: italic;
+  line-height: 1.5;
+  margin-top: 2.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.prose-blog p:has(> img) > img {
+  margin-bottom: 0.75rem;
+}
+
 .prose-blog code:not(pre code) {
   background: var(--tech-bg);
   padding: 2px 6px;


### PR DESCRIPTION
Blog post pages were missing the prose styling they assumed. The `.prose-blog` class relied on `@apply prose prose-lg max-w-none`, but Tailwind and the typography plugin aren't installed, so the directive was a no-op. The result was paragraphs without spacing, unstyled headings, and oversized portrait photos that dominated the viewport (visible on posts like the Mt. Rainier write-up).

## Changes

All in `src/styles/global.css` under `.prose-blog`:

- Replaced the dead `@apply prose` rule with explicit styles for paragraphs (1.5em bottom margin, 1.75 line-height), headings, lists, blockquotes, `hr`, and `strong`.
- Capped post images at `max-height: 70vh` while preserving aspect ratio, centered them, and added the site's rounded-corner radius so tall portrait shots no longer overwhelm the page.
- Styled image captions: paragraphs that contain an `<img>` are now centered, smaller (0.875rem), italic, and muted, with a bit of vertical breathing room around the figure.

No content or layout component changes; this is purely CSS.